### PR TITLE
Port Test262 Atomic's nan-timeout.js test to WebWorker

### DIFF
--- a/atomics/wait/web-worker-agent/nan-timeout.htm
+++ b/atomics/wait/web-worker-agent/nan-timeout.htm
@@ -10,20 +10,23 @@ Tests Atomics.wait in a web worker.  The worker thread waits on the
 SharedArrayBuffer slot 0 to with a NaN timeout.
 */
 
-test(function(t) {
+window.addEventListener("load", function() {
+  async_test(function(t) {
     var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
     var worker = new Worker("workers/nan-timeout.js");
     window.setTimeout(() => Atomics.wake(ia, 0), 1000);
-    
+
     worker.onerror = function(e) {
       assert_false(true);
     }
-    worker.onmessage = function(e) {
+    worker.onmessage = this.step_func(function(e) {
       let val = e.data[0];
       if (typeof val == "undefined") return;
-      assert_true(val, "ok");
-    }
+      assert_equals(val, "ok");
+      t.done();
+    });
     worker.postMessage([ia]);
+  }, "dedicated-worker-atomics-nan-timeout");
 });
 
 </script>

--- a/atomics/wait/web-worker-agent/nan-timeout.htm
+++ b/atomics/wait/web-worker-agent/nan-timeout.htm
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+
+/**
+Tests Atomics.wait in a web worker.  The worker thread waits on the
+SharedArrayBuffer slot 0 to with a NaN timeout.
+*/
+
+test(function(t) {
+    var ia = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+    var worker = new Worker("workers/nan-timeout.js");
+    window.setTimeout(() => Atomics.wake(ia, 0), 1000);
+    
+    worker.onerror = function(e) {
+      assert_false(true);
+    }
+    worker.onmessage = function(e) {
+      let val = e.data[0];
+      if (typeof val == "undefined") return;
+      assert_true(val, "ok");
+    }
+    worker.postMessage([ia]);
+});
+
+</script>

--- a/atomics/wait/web-worker-agent/workers/nan-timeout.js
+++ b/atomics/wait/web-worker-agent/workers/nan-timeout.js
@@ -2,9 +2,7 @@ importScripts('/resources/testharness.js');
 
 onmessage = function(e) {
   let sab = e.data[0];
-  assert_true(false);
   assert_equals(sab[0], 0);
   let ret = Atomics.wait(sab, 0, 0);
-  assert_equals(ret, "ok");
   postMessage([ret]);
 }

--- a/atomics/wait/web-worker-agent/workers/nan-timeout.js
+++ b/atomics/wait/web-worker-agent/workers/nan-timeout.js
@@ -1,0 +1,10 @@
+importScripts('/resources/testharness.js');
+
+onmessage = function(e) {
+  let sab = e.data[0];
+  assert_true(false);
+  assert_equals(sab[0], 0);
+  let ret = Atomics.wait(sab, 0, 0);
+  assert_equals(ret, "ok");
+  postMessage([ret]);
+}


### PR DESCRIPTION
This PR ports Test262 Atomic's `nan-timeout.js` test (https://github.com/tc39/test262/blob/master/test/built-ins/Atomics/wait/nan-timeout.js). The test is reworked so the agent is replaced with a Web Worker agent.

The test works fine, the problem is that the test in the main process finishes (and reports test succeeded) before the worker finishes its execution. If for any reason any of the asserts in the worker fails, the test would still be reported as succeeded. The reason for that is that the test is wrapped as a standard "test". WPT test harnessing API (http://web-platform-tests.org/writing-tests/testharness-api.html) offers a variety of tests: **test**, **async_test** and **promise_test**. What would be the best choice to code  worker test? 